### PR TITLE
OCPBUGS-31407: fix pext e2e: The HAProxy router should expose

### DIFF
--- a/installer-upi/aws/cloudformation/templates/03_cluster_security.yaml
+++ b/installer-upi/aws/cloudformation/templates/03_cluster_security.yaml
@@ -504,6 +504,16 @@ Resources:
       ToPort: 32767
       IpProtocol: udp
 
+  WorkerIngressE2eTestHaproxy:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: E2E workaround for exposing haproxy routes
+      FromPort: 1936
+      ToPort: 1936
+      IpProtocol: tcp
+
   MasterIamRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
Fix haproxy e2e tests* failing in OPCT workflow, skipped in the CI e2e workflow, due a issue in the platform external provisioning scripts missing to ingress port 1936/TCP between the worker nodes.

https://issues.redhat.com/browse/SPLAT-2092
https://issues.redhat.com/browse/OCPBUGS-31407