### PR TITLE
OCPBUGS-87972: add TG fields to handling terminating connections

### DIFF
--- a/installer-upi/aws/cloudformation/templates/02_cluster_infra.yaml
+++ b/installer-upi/aws/cloudformation/templates/02_cluster_infra.yaml
@@ -189,6 +189,10 @@ Resources:
       TargetGroupAttributes:
       - Key: deregistration_delay.timeout_seconds
         Value: 60
+      - Key: target_health_state.unhealthy.connection_termination.enabled
+        Value: false
+      - Key: target_health_state.unhealthy.draining_interval_seconds
+        Value: 60
 
   InternalApiListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -218,6 +222,10 @@ Resources:
         Ref: VpcId
       TargetGroupAttributes:
       - Key: deregistration_delay.timeout_seconds
+        Value: 60
+      - Key: target_health_state.unhealthy.connection_termination.enabled
+        Value: false
+      - Key: target_health_state.unhealthy.draining_interval_seconds
         Value: 60
 
   InternalServiceInternalListener:


### PR DESCRIPTION
Setting TG fields to improve the termination handling timers used/evaluated in the e2e test

[sig-api-machinery][Feature:APIServer] API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients

observed as permanent failure in different jobs reported by https://redhat.atlassian.net/browse/OCPBUGS-87972 .

Historically in platform integrated NLB transictioning timers reports delays on AWS (integrated), this change intends to validate if it will be fixed in agnostic installations.

Relates to  https://github.com/openshift/release/pull/80100 